### PR TITLE
fix: use ctrl-f tmux prefix

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -5,12 +5,12 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 
-# use Ctrl-k for the prefix.
+# use Ctrl-f for the prefix.
 unbind C-b
 unbind C-j
-set-option -g prefix C-k
-bind-key C-k send-prefix
-# set-option -g prefix2 C-f 
+unbind C-k
+set-option -g prefix C-f
+bind-key C-f send-prefix
 set -g mouse on
 
 # Tmux Reload with prefix and r.
@@ -67,7 +67,8 @@ bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
 bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -in -selection clipboard"
 
-# Keep Ctrl-h/j/k/l reserved from root-level plugin bindings on this machine.
+# Keep Ctrl-f for the prefix and Ctrl-h/j/k/l for Neovim navigation.
+unbind -n C-f
 unbind -n C-h
 unbind -n C-j
 unbind -n C-k


### PR DESCRIPTION
## Summary
- change the tmux prefix from Ctrl-k to Ctrl-f
- remove the old Ctrl-k send-prefix binding on reload
- reserve root-level Ctrl-f for the tmux prefix

## Verification
- tmux show-option -gqv prefix returns C-f
- tmux list-keys -T prefix C-f shows send-prefix