### PR TITLE
Chore: Ignore Opencode Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ state.yml
 .zsh_history
 .wakatime.cfg
 .zshrc
+.config/opencode/


### PR DESCRIPTION
Ignores local opencode configuration under .config/opencode.\n\nStack: 2/4\n\nValidation:\n- Reviewed diff\n- Secret keyword scan reviewed

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #17
2. **#18** 👈 current
3. #19
4. #20
<!-- stack:links:end -->