### PR TITLE
Fix Ghostty Transparency

### DIFF
--- a/.config/ghostty/config.ghostty
+++ b/.config/ghostty/config.ghostty
@@ -1,0 +1,1 @@
+background-opacity = 0.9


### PR DESCRIPTION
## Summary
- add Ghostty config with background opacity for transparent terminal windows
- OpenCode inherits transparency when run inside Ghostty

## Tests
- not run; config-only change