### PR TITLE
Fix I3 Ghostty Terminal Shortcut

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -58,7 +58,7 @@ floating_modifier $mod
 tiling_drag modifier titlebar
 
 # start a terminal
-bindsym $mod+Return exec alacritty
+bindsym $mod+Return exec ghostty
 
 # kill focused window
 bindsym $mod+Shift+q kill


### PR DESCRIPTION
## Summary
- update Alt+Enter terminal shortcut to launch Ghostty instead of Alacritty

## Tests
- i3 -C -c /home/bupd/dotfiles/.config/i3/config
- i3-msg reload